### PR TITLE
Reduced docker image size from 2+ GB to ~300MB and built it for arm64 devices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
 FROM python:3.9.14-slim-bullseye
 
-
 WORKDIR /app
 
-COPY requirements-web.txt src/bibler/requirements-web.txt
+RUN apt-get update && apt-get install -y --no-install-recommends gcc build-essential && apt-get clean -y && rm -rf /var/lib/apt/lists/* 
 
-RUN pip install -U -r src/bibler/requirements-web.txt
+COPY src/bibler/requirements-web.txt requirements-web.txt
 
-RUN python -m spacy download en_core_web_trf
+RUN BLIS_ARCH="generic" pip install spacy --no-binary blis
 
-COPY . /app
+RUN pip install -U -r requirements-web.txt
 
-CMD ["python", "src/bibler/web.py"]
+COPY src/bibler/ /app
+
+COPY entrypoint.sh /app/entrypoint.sh
+
+RUN chmod +x /app/entrypoint.sh
+
+CMD ["/bin/sh", "-c", "/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Install spaCy desired model
+python -m spacy download en_core_web_trf
+
+# Run the Python application
+python web.py

--- a/src/bibler/requirements-web.txt
+++ b/src/bibler/requirements-web.txt
@@ -1,3 +1,2 @@
 fastapi
 uvicorn[standard]
-spacy

--- a/src/bibler/web.py
+++ b/src/bibler/web.py
@@ -230,4 +230,4 @@ if __name__ == "__main__":
         uvicorn.run(app, host="0.0.0.0", port=80, log_level="info")
     else:
         # running a Debug server
-        uvicorn.run(app, host="0.0.0.0", port=8000, debug=True)
+        uvicorn.run(app, host="0.0.0.0", port=8000, log_level='debug')


### PR DESCRIPTION
Removed the space model weights embedded in image and let it download on the fly, reducing the image size significantly. Also built it to run on ARM64 devices (like Apple Silicon Mac's) that can be found here https://hub.docker.com/r/relis/bibler/tags 